### PR TITLE
fix spec/find-db-dir-Spec on Windows

### DIFF
--- a/spec/find-db-dir-Spec.js
+++ b/spec/find-db-dir-Spec.js
@@ -15,7 +15,7 @@ describe('findDbDir', () => {
     describe('when db in parent dir,', () => {
       let pfs = {
         exists: (_path) => {
-          return new Promise((resolve, reject) => resolve(_path === parent_dir + '/db'))
+          return new Promise((resolve, reject) => resolve(_path === path.join(parent_dir,'db')))
         }
       };
       let result;
@@ -33,7 +33,7 @@ describe('findDbDir', () => {
       describe('and parent-of-parent has db,', () => {
         let pfs = {
           exists: (_path) => {
-            return new Promise((resolve, reject) => resolve(_path === parent_parent_dir + '/db'))
+            return new Promise((resolve, reject) => resolve(_path === path.join(parent_parent_dir, 'db') ))
           }
         }
 
@@ -63,7 +63,7 @@ describe('findDbDir', () => {
         })
 
         it('must fail via catch', () => {
-          expect(result).toBe('db was not found at ' + parent_parent_dir + '/db');
+          expect(result).toBe('db was not found at ' + path.join(parent_parent_dir, 'db') );
         })
       })
       


### PR DESCRIPTION
Running specs on Windows fails for `find-db-dir-Spec.js` because POSIX file separators were assumed.
Fixing by use of path.join to make it OS agnostic.